### PR TITLE
Rename .share-btn to .share-ordla-result

### DIFF
--- a/src/SummaryModal.tsx
+++ b/src/SummaryModal.tsx
@@ -186,7 +186,7 @@ ${resultsString}
         )}
       </Fade>
       <button
-        className="share-btn"
+        className="share-ordla-result"
         onClick={() => {
           if (navigator.share) {
             navigator.share(data);

--- a/src/index.css
+++ b/src/index.css
@@ -161,7 +161,7 @@ p {
   font-weight: 500;
 }
 
-.share-btn {
+.share-ordla-result {
   padding: 12px 24px;
   border-radius: 9px;
   font-weight: 600;


### PR DESCRIPTION
This prevents the button from being hidden by various adblocking software