### PR TITLE
Warn when using letter known to be wrong

### DIFF
--- a/src/Help.tsx
+++ b/src/Help.tsx
@@ -50,7 +50,7 @@ function Example({ word, guess }: { word: string; guess: string }) {
   return (
     <div className="row gap-s">
       {guess.split("").map((l, i) => (
-        <Square word={word} letter={l} key={l} index={i} isCurrentTry={false} />
+        <Square word={word} letter={l} key={l} index={i} isCurrentTry={false} tries={[]} />
       ))}
     </div>
   );

--- a/src/Square.tsx
+++ b/src/Square.tsx
@@ -4,8 +4,9 @@ export function Square(props: {
   guess?: string;
   isCurrentTry: boolean;
   word: string;
+  tries: string[];
 }) {
-  const { index, letter, word, isCurrentTry, guess } = props;
+  const { index, letter, word, isCurrentTry, guess, tries } = props;
   const hit = !isCurrentTry && word[index] === letter;
   const letterOccurrances = word.split("").filter((l) => l === letter).length;
   const letterHitsElsewhere =
@@ -52,6 +53,13 @@ export function Square(props: {
     isExtranousAlmost = indicesOfOccurrencesInGuess[index] !== 1;
   }
 
+  // warn if the letter is already known to not exist
+  const warn =
+      isCurrentTry
+      && letter
+      && word.indexOf(letter) === -1
+      && tries.some((t) => t.indexOf(letter) > -1);
+
   return (
     <div
       className="center letter"
@@ -68,6 +76,8 @@ export function Square(props: {
           ? "var(--letter-bg--hit)"
           : almost && !isExtranousAlmost
           ? "var(--letter-bg--almost)"
+          : warn
+          ? "var(--letter-bg--warn)"
           : "var(--letter-bg)",
       }}
     >

--- a/src/Tries.tsx
+++ b/src/Tries.tsx
@@ -24,6 +24,7 @@ export function Tries(props: {
                 word={word}
                 letter={letter}
                 key={"" + letter + i + j}
+                tries={[...tries]}
               />
             );
           })}

--- a/src/index.css
+++ b/src/index.css
@@ -4,6 +4,7 @@
 
   --letter-bg: rgba(37 49 56);
   --letter-bg--hit: rgba(0 178 0);
+  --letter-bg--warn: rgba(178 0 0);
   --bar-color: rgba(0 150 0);
   --letter-bg--almost: rgb(161, 121, 10);
   --letter-text: rgba(255 255 255 / 0.9);


### PR DESCRIPTION
This adds a new background color (red as an example) for letters in the current attempt which are known to not exist in the correct word.

I have not updated the display-p3, nor have I updated the light color scheme, as I'm assuming you will want to adjust the color anyway, should this PR be accepted.

In the example below, note that `N` is known not to be correct. Also note that it is only highlighted in the _current attempt_ -- in other words, after completing the attempt and hitting Enter, the highlighted background color disappears.

<img width="339" alt="image" src="https://user-images.githubusercontent.com/50928/158094165-b982fec7-6b9f-4702-89a7-36b98a8b6e35.png">

Please let me know what you think.